### PR TITLE
The `require_ssl` argument is deprecated

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: check-symlinks
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.92.0
+    rev: v1.92.1
     hooks:
       - id: terraform_fmt
 
@@ -29,7 +29,7 @@ repos:
       - id: terraform_docs
 
   - repo: https://github.com/bridgecrewio/checkov.git
-    rev: 3.2.213
+    rev: 3.2.219
     hooks:
       - id: checkov
         verbose: true

--- a/regional/README.md
+++ b/regional/README.md
@@ -11,7 +11,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 5.32.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 5.40.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.6.2 |
 
 ## Modules

--- a/regional/main.tf
+++ b/regional/main.tf
@@ -20,7 +20,7 @@ resource "google_sql_database_instance" "this" {
   # checkov -f tfplan.json
 
   # Ensure all Cloud SQL database instance requires all incoming connections to use SSL
-  # checkov:skip=CKV_GCP_6: The require_ssl is deprecated: https://github.com/bridgecrewio/checkov/issues/6102
+  # checkov:skip=CKV_GCP_6: The require_ssl argument is deprecated: https://github.com/bridgecrewio/checkov/issues/6102
 
   database_version    = var.database_version
   deletion_protection = var.deletion_protection

--- a/regional/main.tf
+++ b/regional/main.tf
@@ -3,7 +3,7 @@
 
 resource "google_sql_database_instance" "this" {
 
-  # Postgres Database Flags
+  # Postgres Database Flags false positives
   # checkov:skip=CKV2_GCP_13
   # checkov:skip=CKV_GCP_51
   # checkov:skip=CKV_GCP_52
@@ -18,6 +18,9 @@ resource "google_sql_database_instance" "this" {
   # terraform plan --out tfplan.binary
   # terraform show -json tfplan.binary | jq > tfplan.json
   # checkov -f tfplan.json
+
+  # Ensure all Cloud SQL database instance requires all incoming connections to use SSL
+  # checkov:skip=CKV_GCP_6: The require_ssl is deprecated: https://github.com/bridgecrewio/checkov/issues/6102
 
   database_version    = var.database_version
   deletion_protection = var.deletion_protection
@@ -54,7 +57,7 @@ resource "google_sql_database_instance" "this" {
     ip_configuration {
       ipv4_enabled    = false
       private_network = local.network
-      require_ssl     = true
+      ssl_mode        = "ENCRYPTED_ONLY"
     }
 
     maintenance_window {
@@ -62,6 +65,7 @@ resource "google_sql_database_instance" "this" {
       hour         = var.mw_hour
       update_track = var.update_track
     }
+
 
     user_labels = var.labels
   }

--- a/regional/outputs.tf
+++ b/regional/outputs.tf
@@ -8,7 +8,7 @@ output "client_cert" {
 
 output "instance_server_ca_cert" {
   description = "The SQL instance server CA certificate"
-  value       = google_sql_database_instance.this.server_ca_cert[0].cert
+  value       = google_sql_database_instance.this.server_ca_cert
   sensitive   = true
 }
 

--- a/tests/default.tftest.hcl
+++ b/tests/default.tftest.hcl
@@ -1,7 +1,21 @@
+mock_provider "google" {}
+
 run "default" {
   command = apply
 
   module {
     source = "./tests/fixtures/default"
   }
+}
+
+variables {
+  client_certs = [
+    "mock-client-cert-a",
+    "mock-client-cert-b"
+  ]
+
+  environment = "mock-environment"
+  host_project_id = "mock-host-project"
+  instance_name = "mock-instance"
+  project = "mock-project"
 }

--- a/tests/default.tftest.hcl
+++ b/tests/default.tftest.hcl
@@ -14,8 +14,8 @@ variables {
     "mock-client-cert-b"
   ]
 
-  environment = "mock-environment"
+  environment     = "mock-environment"
   host_project_id = "mock-host-project"
-  instance_name = "mock-instance"
-  project = "mock-project"
+  instance_name   = "mock-instance"
+  project         = "mock-project"
 }

--- a/tests/fixtures/default/locals.tf
+++ b/tests/fixtures/default/locals.tf
@@ -1,0 +1,12 @@
+# Local Values
+# https://www.terraform.io/docs/language/values/locals.html
+
+locals {
+  labels = {
+    cost-center = "mock-x001"
+    env         = var.environment
+    repository  = "mock-repository"
+    platform    = "mock-platform"
+    team        = "mock-team"
+  }
+}

--- a/tests/fixtures/default/main.tf
+++ b/tests/fixtures/default/main.tf
@@ -1,3 +1,11 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
 module "test" {
   source = "../../../regional"
 
@@ -5,28 +13,17 @@ module "test" {
 
   postgres_database_flags = [
     {
-      name  = "autovacuum"
+      name  = "mock"
       value = "on"
-    },
-    {
-      name  = "deadlock_timeout"
-      value = 2000
     }
   ]
 
-  deletion_protection = false
-  host_project_id     = var.host_project_id
-  instance_name       = var.instance_name
-
-  labels = {
-    cost-center = "x000"
-    env         = "sb"
-    repository  = "terraform-google-cloud-sql"
-    team        = "testing"
-  }
-
-  network                        = "terraform-test-vpc"
+  deletion_protection            = false
+  host_project_id                = var.host_project_id
+  instance_name                  = var.instance_name
+  labels                         = local.labels
+  network                        = "mock-vpc"
   point_in_time_recovery_enabled = true
   project                        = var.project
-  region                         = "us-east1"
+  region                         = "mock-region"
 }

--- a/tests/fixtures/default/variables.tf
+++ b/tests/fixtures/default/variables.tf
@@ -1,22 +1,19 @@
 variable "client_certs" {
   type = set(string)
-  default = [
-    "client-cert1",
-    "client-cert2"
-  ]
+}
+
+variable "environment" {
+  type = string
 }
 
 variable "host_project_id" {
-  type    = string
-  default = "test-default-tf75-sb"
+  type = string
 }
 
 variable "project" {
-  type    = string
-  default = "test-gke-fleet-member-tfc5-sb"
+  type = string
 }
 
 variable "instance_name" {
-  type    = string
-  default = "test"
+  type = string
 }


### PR DESCRIPTION
https://github.com/bridgecrewio/checkov/issues/6102

Fixes #52

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Upgraded the Google provider version to enhance capabilities and introduce potential new features.
	- Updated pre-commit tool versions for improved performance and functionality. 
	- Added a new section for variables in tests to promote configurability.

- **Bug Fixes**
	- Replaced deprecated `require_ssl` attribute with `ssl_mode` for better SSL connection enforcement.

- **Documentation**
	- Clarified comments within configuration files for better understanding and compliance with best practices.

- **Chores**
	- Introduced local values for better manageability of resource labels in Terraform configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->