### PR TITLE
Bump PostgreSQL version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
@@ -11,7 +11,7 @@ repos:
       - id: check-symlinks
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.95.0
+    rev: v1.96.3
     hooks:
       - id: terraform_fmt
 
@@ -29,7 +29,7 @@ repos:
       - id: terraform_docs
 
   - repo: https://github.com/bridgecrewio/checkov.git
-    rev: 3.2.254
+    rev: 3.2.344
     hooks:
       - id: checkov
         verbose: true

--- a/README.md
+++ b/README.md
@@ -56,10 +56,6 @@ Links to documentation and other resources required to develop and iterate in th
 All tests are [mocked](https://developer.hashicorp.com/terraform/language/tests/mocking) allowing us to test the module without creating infrastructure or requiring credentials. The trade-offs are acceptable in favor of speed and simplicity. In a Terraform test, a mocked provider or resource will generate fake data for all computed attributes that would normally be provided by the underlying provider APIs.
 
 ```none
-cd fixtures/default
-```
-
-```none
 terraform init
 ```
 

--- a/regional/README.md
+++ b/regional/README.md
@@ -11,7 +11,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 6.2.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 6.14.1 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.6.3 |
 
 ## Modules
@@ -33,7 +33,7 @@ No modules.
 | <a name="input_availability_type"></a> [availability\_type](#input\_availability\_type) | The availability type of the Cloud SQL instance | `string` | `"REGIONAL"` | no |
 | <a name="input_backup_start_time"></a> [backup\_start\_time](#input\_backup\_start\_time) | Time indicating when backup configuration starts | `string` | `"04:00"` | no |
 | <a name="input_client_certs"></a> [client\_certs](#input\_client\_certs) | A set of client cert names, note: 10 max per instance | `set(string)` | `[]` | no |
-| <a name="input_database_version"></a> [database\_version](#input\_database\_version) | The MySQL, PostgreSQL or SQL Server version to use. | `string` | `"POSTGRES_15"` | no |
+| <a name="input_database_version"></a> [database\_version](#input\_database\_version) | The MySQL, PostgreSQL or SQL Server version to use. | `string` | `"POSTGRES_16"` | no |
 | <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Whether or not to allow Terraform to destroy the instance | `bool` | `true` | no |
 | <a name="input_host_project_id"></a> [host\_project\_id](#input\_host\_project\_id) | Host project ID for the shared VPC | `string` | `""` | no |
 | <a name="input_instance_name"></a> [instance\_name](#input\_instance\_name) | The name of the instance | `string` | n/a | yes |
@@ -43,7 +43,7 @@ No modules.
 | <a name="input_mw_hour"></a> [mw\_hour](#input\_mw\_hour) | Maintenance window hour | `number` | `17` | no |
 | <a name="input_network"></a> [network](#input\_network) | The VPC network from which the Cloud SQL instance is accessible for private IP | `string` | n/a | yes |
 | <a name="input_point_in_time_recovery_enabled"></a> [point\_in\_time\_recovery\_enabled](#input\_point\_in\_time\_recovery\_enabled) | True if Point-in-time recovery is enabled. Will restart database if enabled after instance creation. Valid only for PostgreSQL instances | `bool` | `false` | no |
-| <a name="input_postgres_database_flags"></a> [postgres\_database\_flags](#input\_postgres\_database\_flags) | The database flags for Cloud SQL. See [PostgreSQL Flags](https://cloud.google.com/sql/docs/postgres/flags) | <pre>list(object({<br>    name  = string<br>    value = string<br>  }))</pre> | `[]` | no |
+| <a name="input_postgres_database_flags"></a> [postgres\_database\_flags](#input\_postgres\_database\_flags) | The database flags for Cloud SQL. See [PostgreSQL Flags](https://cloud.google.com/sql/docs/postgres/flags) | <pre>list(object({<br/>    name  = string<br/>    value = string<br/>  }))</pre> | `[]` | no |
 | <a name="input_project"></a> [project](#input\_project) | The ID of the project in which the resource belongs | `string` | n/a | yes |
 | <a name="input_query_insights_enabled"></a> [query\_insights\_enabled](#input\_query\_insights\_enabled) | True if Query Insights feature is enabled | `bool` | `true` | no |
 | <a name="input_query_plans_per_minute"></a> [query\_plans\_per\_minute](#input\_query\_plans\_per\_minute) | Number of query execution plans captured by Insights per minute for all queries combined. Between 0 and 20 | `number` | `5` | no |

--- a/regional/README.md
+++ b/regional/README.md
@@ -38,7 +38,7 @@ No modules.
 | <a name="input_host_project_id"></a> [host\_project\_id](#input\_host\_project\_id) | Host project ID for the shared VPC | `string` | `""` | no |
 | <a name="input_instance_name"></a> [instance\_name](#input\_instance\_name) | The name of the instance | `string` | n/a | yes |
 | <a name="input_labels"></a> [labels](#input\_labels) | A map of key/value pairs to assign to the resources being created | `map(string)` | `{}` | no |
-| <a name="input_machine_tier"></a> [machine\_tier](#input\_machine\_tier) | The machine type to use. Postgres supports only shared-core machine types, and custom machine types such as db-custom-2-13312 | `string` | `"db-n1-standard-1"` | no |
+| <a name="input_machine_tier"></a> [machine\_tier](#input\_machine\_tier) | The machine type to use. Postgres supports only shared-core machine types, and custom machine types such as db-custom-2-13312 | `string` | `"db-f1-micro"` | no |
 | <a name="input_mw_day"></a> [mw\_day](#input\_mw\_day) | Maintenance window day | `number` | `4` | no |
 | <a name="input_mw_hour"></a> [mw\_hour](#input\_mw\_hour) | Maintenance window hour | `number` | `17` | no |
 | <a name="input_network"></a> [network](#input\_network) | The VPC network from which the Cloud SQL instance is accessible for private IP | `string` | n/a | yes |

--- a/regional/README.md
+++ b/regional/README.md
@@ -11,8 +11,8 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 6.14.1 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.6.3 |
+| <a name="provider_google"></a> [google](#provider\_google) | 5.38.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.6.2 |
 
 ## Modules
 
@@ -38,7 +38,7 @@ No modules.
 | <a name="input_host_project_id"></a> [host\_project\_id](#input\_host\_project\_id) | Host project ID for the shared VPC | `string` | `""` | no |
 | <a name="input_instance_name"></a> [instance\_name](#input\_instance\_name) | The name of the instance | `string` | n/a | yes |
 | <a name="input_labels"></a> [labels](#input\_labels) | A map of key/value pairs to assign to the resources being created | `map(string)` | `{}` | no |
-| <a name="input_machine_tier"></a> [machine\_tier](#input\_machine\_tier) | The machine type to use. Postgres supports only shared-core machine types, and custom machine types such as db-custom-2-13312 | `string` | `"db-f1-micro"` | no |
+| <a name="input_machine_tier"></a> [machine\_tier](#input\_machine\_tier) | The machine type to use. Postgres supports only shared-core machine types, and custom machine types such as db-custom-2-13312 | `string` | `"db-n1-standard-1"` | no |
 | <a name="input_mw_day"></a> [mw\_day](#input\_mw\_day) | Maintenance window day | `number` | `4` | no |
 | <a name="input_mw_hour"></a> [mw\_hour](#input\_mw\_hour) | Maintenance window hour | `number` | `17` | no |
 | <a name="input_network"></a> [network](#input\_network) | The VPC network from which the Cloud SQL instance is accessible for private IP | `string` | n/a | yes |

--- a/regional/locals.tf
+++ b/regional/locals.tf
@@ -2,6 +2,7 @@
 # https://www.terraform.io/docs/language/values/locals.html
 
 locals {
+  name    = "${var.instance_name}-${random_id.this.hex}-${var.region}"
   network = "projects/${var.host_project_id}/global/networks/${var.network}"
 
   # These flags are required for CIS GCP v1.3.0 compliance

--- a/regional/main.tf
+++ b/regional/main.tf
@@ -24,7 +24,7 @@ resource "google_sql_database_instance" "this" {
 
   database_version    = var.database_version
   deletion_protection = var.deletion_protection
-  name                = "${var.instance_name}-${random_id.this.hex}-${var.region}"
+  name                = local.name
   project             = var.project
   region              = var.region
 
@@ -66,14 +66,7 @@ resource "google_sql_database_instance" "this" {
       update_track = var.update_track
     }
 
-
     user_labels = var.labels
-  }
-
-  timeouts {
-    create = "60m"
-    delete = "60m"
-    update = "60m"
   }
 }
 

--- a/regional/main.tf
+++ b/regional/main.tf
@@ -30,6 +30,7 @@ resource "google_sql_database_instance" "this" {
 
   settings {
     availability_type = var.availability_type
+    edition           = "ENTERPRISE"
     tier              = var.machine_tier
 
     backup_configuration {

--- a/regional/variables.tf
+++ b/regional/variables.tf
@@ -51,7 +51,7 @@ variable "labels" {
 variable "machine_tier" {
   description = "The machine type to use. Postgres supports only shared-core machine types, and custom machine types such as db-custom-2-13312"
   type        = string
-  default     = "db-n1-standard-1"
+  default     = "db-f1-micro"
 }
 
 variable "mw_day" {

--- a/regional/variables.tf
+++ b/regional/variables.tf
@@ -22,7 +22,7 @@ variable "client_certs" {
 variable "database_version" {
   description = "The MySQL, PostgreSQL or SQL Server version to use."
   type        = string
-  default     = "POSTGRES_15"
+  default     = "POSTGRES_16"
 }
 
 variable "deletion_protection" {

--- a/regional/variables.tf
+++ b/regional/variables.tf
@@ -51,7 +51,7 @@ variable "labels" {
 variable "machine_tier" {
   description = "The machine type to use. Postgres supports only shared-core machine types, and custom machine types such as db-custom-2-13312"
   type        = string
-  default     = "db-f1-micro"
+  default     = "db-n1-standard-1"
 }
 
 variable "mw_day" {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Streamlined instructions for initializing and testing Terraform in the README.
	- Updated default PostgreSQL version to `"POSTGRES_16"` for Cloud SQL instances.
	- Added a new local variable `name` in the Terraform configuration.
	- Introduced a new attribute `edition` set to "ENTERPRISE" in the Cloud SQL instance settings.

- **Bug Fixes**
	- Corrected formatting in the documentation for `postgres_database_flags`.

- **Chores**
	- Updated versions of pre-commit hooks and Terraform provider in configuration files.
	- Updated default machine tier to `"db-n1-standard-1"` for Cloud SQL instances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->